### PR TITLE
Test if connect() throw an unhandled exception

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -160,7 +160,7 @@ export default class Client {
           clearTimeout(connectionTimeout)
           this._changeState(STATE_NOT_AUTHENTICATED)
           this.updateCapability()
-            .then(() => resolve(this._capability))
+            .then(() => resolve(this._capability), reject)
         }
 
         this.client.onerror = (err) => {


### PR DESCRIPTION
I just find an issue with connect. When called on certain server the connection failed.
It throw correctly the error but an unhandle promise is also rejected. it should not be cough by the system and should be normally trapped.
I didn't investigate much more at the moment as I spend more time to reproduce the issue and create a test case.
I will come back with more detail to understand why connecting on that server trigger the `unhandledRejection` event.

If you have any suggestion on modification or code to adjust please don't hesitate 🙏